### PR TITLE
feat: callback now take the received doc from mongodb

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rs-mongo-stream"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["LSH <github@lsh.tech>"]
 edition = "2021"
 description = "Wrapper on mongo to easier the way to handle mongo stream"


### PR DESCRIPTION
# Pull Request: feat/use_doc_in_callback

## Summary

This PR enhances the callback functionality in the MongoStream library by providing the full MongoDB document to callback handlers instead of just the event type. This is a breaking API change that enables more meaningful interaction with change stream data, allowing callbacks to access and work with the actual document content that triggered the event.

## Commit History

* a11e5d0 - feat: callback now take the received doc from mongodb

## Changes

- Modified the `CallbackFn` type to accept `&Document` instead of `&Event`
- Updated callback implementations to work with the document parameter
- Changed callback invocation to pass the actual MongoDB document
- Bumped library version from 0.2.0 to 0.3.0 to reflect the breaking API change

## Technical Details

- Changed 2 files with 14 insertions and 10 deletions
- Modified callback signature: `Fn(&Event)` → `Fn(&Document)`
- Added document retrieval from change stream events
- Updated tests to accommodate the new callback signature

## Testing

The existing test suite has been updated to verify that callbacks receive document objects correctly and can process them as expected.

## Additional Notes

This is a breaking change for any code using the callback functionality. Users will need to update their callback functions to accept a `&Document` parameter instead of an `&Event`. The benefit is that callbacks now have direct access to the actual document data, making them more useful in real-world scenarios.
