### PR TITLE
doc: update readme to version 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Add the crate to your Cargo.toml:
 
 ```toml
 [dependencies]
-rs-mongo-stream = "0.1.0"
+rs-mongo-stream = "0.3.0"
 mongodb = "2.4.0"
 tokio = { version = "1", features = ["full"] }
 ```
@@ -50,23 +50,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut stream = MongoStream::new(client.clone(), db);
     
     // Register callbacks for a collection
-    stream.add_callback("users", Event::Insert("".to_string()), |event| {
+    stream.add_callback("users", Event::Insert, |doc| {
         Box::pin(async move {
-            println!("New user inserted: {:?}", event);
+            println!("New user inserted: {:?}", doc);
             // Handle the insertion...
         })
     });
     
-    stream.add_callback("users", Event::Update("".to_string()), |event| {
+    stream.add_callback("users", Event::Update, |doc| {
         Box::pin(async move {
-            println!("User updated: {:?}", event);
+            println!("User updated: {:?}", doc);
             // Handle the update...
         })
     });
     
-    stream.add_callback("users", Event::Delete("".to_string()), |event| {
+    stream.add_callback("users", Event::Delete, |doc| {
         Box::pin(async move {
-            println!("User deleted: {:?}", event);
+            println!("User deleted: {:?}", doc);
             // Handle the deletion...
         })
     });


### PR DESCRIPTION
# Pull Request: doc/update_readme

## Summary

This PR updates the README.md to reflect changes in version 0.3.0 of the rs-mongo-stream crate. The documentation has been updated to show the current API usage patterns and the latest version number.

## Key Changes

- Updated the version number in the dependency section from 0.1.0 to 0.3.0
- Updated the callback API examples:
  - Removed string parameter from Event enum constructors (Insert, Update, Delete)
  - Changed callback parameter naming from `event` to `doc` for better clarity
  - Updated the corresponding print statements to reflect the parameter name change

## Commit History

* d1a693b - doc: update accordally to version 0.3.0

## Testing

Documentation changes only, no functional testing required.

## Additional Notes

These documentation updates ensure that users following the README examples will use the current API patterns available in version 0.3.0.